### PR TITLE
Fix: Macro Expansion 

### DIFF
--- a/lib/elixact/types.ex
+++ b/lib/elixact/types.ex
@@ -99,7 +99,7 @@ defmodule Elixact.Types do
 
       other ->
         if match?({:module, _}, Code.ensure_compiled(other)) &&
-+             function_exported?(other, :type_definition, 0) do
+             function_exported?(other, :type_definition, 0) do
           other.type_definition()
         else
           # Assume schema module reference

--- a/lib/elixact/types.ex
+++ b/lib/elixact/types.ex
@@ -98,7 +98,8 @@ defmodule Elixact.Types do
         {:type, type, []}
 
       other ->
-        if Code.ensure_loaded?(other) && function_exported?(other, :type_definition, 0) do
+        if match?({:module, _}, Code.ensure_compiled(other)) &&
++             function_exported?(other, :type_definition, 0) do
           other.type_definition()
         else
           # Assume schema module reference


### PR DESCRIPTION
Field macro expansion results depend on the module loading order. 

E.g if we use a custom type, that represents a union of other types, it might expand:
- to {:union, [...]} type in `field_meta` if the module with this custom type is already loaded
- or to {:ref, module_atom} if it's not yet loaded (see `normalize_type` function)

So, let's wait for the module to be fully loaded and compiled.