### PR TITLE
fix: 'typing violation found use Elixact.Type' warning suppressed

### DIFF
--- a/lib/elixact/type.ex
+++ b/lib/elixact/type.ex
@@ -47,7 +47,7 @@ defmodule Elixact.Type do
       end
 
       # Default implementations that can be overridden
-      def coerce_rule, do: nil
+      def coerce_rule, do: Process.get(make_ref(), nil)
       def custom_rules, do: []
 
       defoverridable coerce_rule: 0, custom_rules: 0


### PR DESCRIPTION
usage of 
`use Elixact.Type`
gives a silly warning 
```
warning: the following clause will never match:

        nil

    because it attempts to match on the result of:

        coerce_rule()

    which has type:

        fun()

    typing violation found at:
    │
  8 │   use Elixact.Type
```
To suppress it we can return a value stored in process. To ensure that the key is not present in process we can use unique reference.
Even though it is hacky it is proposed by Jose Valim in
https://elixirforum.com/t/elixir-v1-18-0-rc-0-released/68015/32